### PR TITLE
Update nix lang link in basics doc

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -39,7 +39,7 @@ hello
 
 
 
-See [Nix language tutorial](https://nix.dev/tutorials/nix-language) for a 1-2 hour deep dive 
+See [Nix language tutorial](https://nix.dev/tutorials/first-steps/nix-language) for a 1-2 hour deep dive 
 that will allow you to read any Nix file.
 
 !!! note


### PR DESCRIPTION
This existing link points to a broken page: https://nix.dev/tutorials/nix-language

Updated it to point to the new page (AFAICT): https://nix.dev/tutorials/first-steps/nix-language